### PR TITLE
[feat] BaseEntity에 Hibernate가 관리하는 TimeStamp 적용

### DIFF
--- a/src/main/java/me/kimhaming/springbootdeveloper/domain/Article.java
+++ b/src/main/java/me/kimhaming/springbootdeveloper/domain/Article.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Article {
+public class Article extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/me/kimhaming/springbootdeveloper/domain/BaseEntity.java
+++ b/src/main/java/me/kimhaming/springbootdeveloper/domain/BaseEntity.java
@@ -1,0 +1,33 @@
+package me.kimhaming.springbootdeveloper.domain;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+// 모든 엔티티에 의해 확장될 기본 클래스 지정
+@MappedSuperclass
+public class BaseEntity {
+//    @CreatedDate
+    // Hibernate 제공 어노테이션
+    @CreationTimestamp
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+//    @LastModifiedDate
+    // Hibernate 제공 어노테이션
+    @UpdateTimestamp
+    @Column
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
- BaseEntity에 createdAt, updatedAt 필드 생성하여 Article에 상속
- Hibernate 가 관리하도록 @CreationTimestamp, @UpdateTimestamp 적용
(트랜잭션 걸릴 때 자동 생성되도록)